### PR TITLE
feat: Abstract spot identification logic

### DIFF
--- a/pkg/cloudprovider/cloud_provider.go
+++ b/pkg/cloudprovider/cloud_provider.go
@@ -8,9 +8,13 @@ import (
 
 // CloudProvider contains the functions for interacting with a cloud provider
 type CloudProvider interface {
-	// DrainExternalLoadBalancerConnections drains connections from external load balancers to a
-	// Kubernetes Node to allow it to be safely deleted
-	DrainExternalLoadBalancerConnections(ctx context.Context, node *corev1.Node) error
-	// DeleteMachine deletes the underlying machine of a Node
-	DeleteMachine(ctx context.Context, node *corev1.Node) error
+	// IsSpotInstance determines whether the underlying instance of the Node is a spot instance
+	IsSpotInstance(ctx context.Context, node *corev1.Node) (bool, error)
+	// DeleteInstance should drain connections from external load balancers to the Node and then
+	// delete the underlying instance. Implementations can assume that before this function is
+	// called the Node has already been modified to ensure that the KCCM service controller will
+	// eventually remove the Node from load balancing although this process may still be in progress
+	// when this function is called:
+	// https://kubernetes.io/docs/concepts/architecture/cloud-controller/#service-controller
+	DeleteInstance(ctx context.Context, node *corev1.Node) error
 }

--- a/pkg/cloudprovider/gcp/cloud_provider_test.go
+++ b/pkg/cloudprovider/gcp/cloud_provider_test.go
@@ -1,0 +1,62 @@
+package gcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsSpotInstance(t *testing.T) {
+	tests := map[string]struct {
+		node           *corev1.Node
+		isSpotInstance bool
+	}{
+		"hasSpotVMLabelSetToTrue": {
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"cloud.google.com/gke-spot": "true",
+					},
+				},
+			},
+			isSpotInstance: true,
+		},
+		"hasSpotVMLabelSetToFalse": {
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"cloud.google.com/gke-spot": "false",
+					},
+				},
+			},
+			isSpotInstance: false,
+		},
+		"hasOtherLabel": {
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+			isSpotInstance: false,
+		},
+		"hasNoLabels": {
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			isSpotInstance: false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cloudProvider := &CloudProvider{}
+			isSpotInstance, err := cloudProvider.IsSpotInstance(context.Background(), test.node)
+			require.Nil(t, err)
+			require.Equal(t, test.isSpotInstance, isSpotInstance)
+		})
+	}
+}


### PR DESCRIPTION
The logic to determine whether a Node has an underlying spot instance is cloud specific: https://cloud.google.com/kubernetes-engine/docs/concepts/spot-vms#scheduling-workloads

This PR adds an `IsSpotInstance` function to the CloudProvider interface to abstract this logic. This PR also combines the `DrainExternalLoadBalancerConnections` and `DeleteMachine` functions into a single `DeleteInstance` function since they are run straight after each other anyway.

Instance was chosen instead of machine to align with the cluster autoscaler: https://github.com/kubernetes/autoscaler/blob/600cda52cf764a1f08b06fc8cc29b1ef95f13c76/cluster-autoscaler/cloudprovider/cloud_provider.go#L239-L247

