### PR TITLE
✨ Reimplement GCP connection draining

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,6 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.54
         args: --timeout=10m
   # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.23.4'
         cache: false
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
@@ -38,7 +38,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.23.4'
     - run: go mod download
     - name: Verify generated code
       run: make verify

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 as build
+FROM golang:1.23.4 as build
 
 WORKDIR /go/src/cost-manager
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hsbc/cost-manager
 
-go 1.21.3
+go 1.23.4
 
 require (
 	github.com/go-logr/logr v1.3.0

--- a/hack/notes/notes.go
+++ b/hack/notes/notes.go
@@ -45,8 +45,8 @@ func run(from, to string) error {
 	if to == "" {
 		to = "HEAD"
 	}
-	var err error
 	if from == "" {
+		var err error
 		from, err = previousTag(to)
 		if err != nil {
 			return err

--- a/pkg/cloudprovider/cloud_provider.go
+++ b/pkg/cloudprovider/cloud_provider.go
@@ -20,10 +20,9 @@ type CloudProvider interface {
 	IsSpotInstance(ctx context.Context, node *corev1.Node) (bool, error)
 	// DeleteInstance should drain connections from external load balancers to the Node and then
 	// delete the underlying instance. Implementations can assume that before this function is
-	// called the Node has already been modified to ensure that the KCCM service controller will
-	// eventually remove the Node from load balancing although this process may still be in progress
-	// when this function is called:
-	// https://kubernetes.io/docs/concepts/architecture/cloud-controller/#service-controller
+	// called Pods have already been drained from the Node and it has been tainted with
+	// ToBeDeletedByClusterAutoscaler to fail kube-proxy health checks as described in KEP-3836:
+	// https://github.com/kubernetes/enhancements/tree/27ef0d9a740ae5058472aac4763483f0e7218c0e/keps/sig-network/3836-kube-proxy-improved-ingress-connectivity-reliability
 	DeleteInstance(ctx context.Context, node *corev1.Node) error
 }
 

--- a/pkg/cloudprovider/gcp/cloud_provider.go
+++ b/pkg/cloudprovider/gcp/cloud_provider.go
@@ -215,7 +215,7 @@ func timeSinceToBeDeletedTaintAdded(node *corev1.Node, now time.Time) time.Durat
 	// Retrieve taint value
 	toBeDeletedTaintAddedValue := ""
 	for _, taint := range node.Spec.Taints {
-		if taint.Key == kubernetes.ToBeDeletedTaint && taint.Value == "ToBeDeletedByClusterAutoscaler" {
+		if taint.Key == kubernetes.ToBeDeletedTaint && taint.Effect == corev1.TaintEffectNoSchedule {
 			toBeDeletedTaintAddedValue = taint.Value
 			break
 		}

--- a/pkg/cloudprovider/gcp/cloud_provider.go
+++ b/pkg/cloudprovider/gcp/cloud_provider.go
@@ -3,15 +3,12 @@ package gcp
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/hsbc/cost-manager/pkg/kubernetes"
 	"github.com/pkg/errors"
 	"google.golang.org/api/compute/v1"
-	"google.golang.org/api/googleapi"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -20,13 +17,6 @@ const (
 	spotNodeLabelKey = "cloud.google.com/gke-spot"
 	// https://cloud.google.com/kubernetes-engine/docs/how-to/preemptible-vms#use_nodeselector_to_schedule_pods_on_preemptible_vms
 	preemptibleNodeLabelKey = "cloud.google.com/gke-preemptible"
-
-	// After kube-proxy starts failing its health check GCP load balancers should mark the instance
-	// as unhealthy within 24 seconds but we wait for slightly longer to give in-flight connections
-	// time to complete before we delete the underlying instance:
-	// https://github.com/kubernetes/ingress-gce/blob/2a08b1e4111a21c71455bbb2bcca13349bb6f4c0/pkg/healthchecksl4/healthchecksl4.go#L48
-	externalLoadBalancerConnectionDrainingPeriod   = 30 * time.Second
-	externalLoadBalancerConnectionDrainingInterval = 5 * time.Second
 )
 
 type CloudProvider struct {
@@ -53,7 +43,7 @@ func (gcp *CloudProvider) DeleteInstance(ctx context.Context, node *corev1.Node)
 	// since this is the connection draining timeout used when GKE subsetting is enabled. We then
 	// add an additional 5 seconds to allow processing time for the various components involved
 	// (e.g. GCP probes and kube-proxy):
-	// https://github.com/kubernetes/cloud-provider-gcp/blob/041c3f47cd8e7e5b7a3954c603255a12e725c78b/providers/gce/gce.go#L75-L82
+	// https://github.com/kubernetes/ingress-gce/blob/2a08b1e4111a21c71455bbb2bcca13349bb6f4c0/pkg/healthchecksl4/healthchecksl4.go#L42
 	time.Sleep(time.Minute - timeSinceToBeDeletedTaintAdded(node, time.Now()))
 
 	// Retrieve instance details from the provider ID
@@ -84,95 +74,6 @@ func (gcp *CloudProvider) DeleteInstance(ctx context.Context, node *corev1.Node)
 		return errors.Wrapf(err, "failed to get compute instance: %s/%s/%s", project, zone, instanceName)
 	}
 
-	// Until KEP-3836 has been released we explicitly remove the instance from any instance groups
-	// managed by the GCP Cloud Controller Manager to trigger connection draining. This is required
-	// since there seems to be a bug in the GCP Cloud Controller Manager where it does not remove an
-	// instance from a backend instance group if it is the last instance in the group; in this case
-	// it updates the backend service to remove the instance group as a backend which does not seem
-	// to trigger connection draining:
-	// https://cloud.google.com/load-balancing/docs/enabling-connection-draining
-	// https://github.com/kubernetes/cloud-provider-gcp/issues/643
-	instanceGroupsListCall := gcp.computeService.InstanceGroups.List(project, zone)
-	for {
-		instanceGroups, err := instanceGroupsListCall.Do()
-		if err != nil {
-			return err
-		}
-		for _, instanceGroup := range instanceGroups.Items {
-			// Only consider instance groups managed by the GCP Cloud Controller Manager:
-			// https://github.com/kubernetes/cloud-provider-gcp/blob/398b1a191aa49b7c67ed5e4677400b73243904e2/providers/gce/gce_loadbalancer_naming.go#L35-L43
-			// TODO(dippynark): Use the cluster ID:
-			// https://github.com/kubernetes/cloud-provider-gcp/blob/398b1a191aa49b7c67ed5e4677400b73243904e2/providers/gce/gce_clusterid.go#L43-L50
-			if !strings.HasPrefix(instanceGroup.Name, "k8s-ig--") {
-				continue
-			}
-			// Ignore empty instance groups
-			if instanceGroup.Size == 0 {
-				continue
-			}
-			instanceGroupInstances, err := gcp.computeService.InstanceGroups.ListInstances(project, zone, instanceGroup.Name, &compute.InstanceGroupsListInstancesRequest{}).Do()
-			if err != nil {
-				return err
-			}
-			for _, instanceGroupInstance := range instanceGroupInstances.Items {
-				if instanceGroupInstance.Instance == instance.SelfLink {
-					// There is a small chance that the GCP Cloud Controller Manager is currently
-					// processing an old list of Nodes so that after we remove the instance from its
-					// instance group the GCP Cloud Controller Manager will add it back. We mitigate
-					// this by periodically attempting to remove the instance. Once KEP-3836 has
-					// been released we will not need to remove the instance, we will just need to
-					// wait for load balancer health checks to mark the instance as unhealthy, so we
-					// periodically attempt removal for the same length of time as we will need to
-					// wait so that connection draining works before and after KEP-3836
-					removeInstance := func() error {
-						operation, err := gcp.computeService.InstanceGroups.RemoveInstances(project, zone, instanceGroup.Name,
-							&compute.InstanceGroupsRemoveInstancesRequest{Instances: []*compute.InstanceReference{{Instance: instance.SelfLink}}}).Do()
-						// Ignore the error if the instance has already been removed
-						if apiErr, ok := err.(*googleapi.Error); ok && apiErr.Code == http.StatusBadRequest &&
-							len(apiErr.Errors) == 1 && apiErr.Errors[0].Reason == "memberNotFound" {
-							return nil
-						}
-						if err != nil {
-							return err
-						}
-						err = gcp.waitForZonalComputeOperation(ctx, project, zone, operation.Name)
-						if err != nil {
-							return err
-						}
-						return nil
-					}
-					// Once KEP-3836 has been released we can simply sleep for the connection
-					// draining period instead of periodically attempting to remove the instance
-					ctxWithTimeout, cancel := context.WithTimeout(ctx, externalLoadBalancerConnectionDrainingPeriod)
-					defer cancel()
-					err := removeInstance()
-					if err != nil {
-						return err
-					}
-				removeInstanceLoop:
-					for {
-						select {
-						case <-ctxWithTimeout.Done():
-							break removeInstanceLoop
-						case <-time.After(externalLoadBalancerConnectionDrainingInterval):
-							err := removeInstance()
-							if err != nil {
-								return err
-							}
-						}
-					}
-				}
-			}
-		}
-		// Continue if there is another page of results...
-		if len(instanceGroups.NextPageToken) > 0 {
-			instanceGroupsListCall.PageToken(instanceGroups.NextPageToken)
-			continue
-		}
-		// ...otherwise we are done
-		break
-	}
-
 	// Determine the managed instance group that created the instance
 	managedInstanceGroupName, err := getManagedInstanceGroupFromInstance(instance)
 	if err != nil {
@@ -189,11 +90,11 @@ func (gcp *CloudProvider) DeleteInstance(ctx context.Context, node *corev1.Node)
 	if err != nil {
 		return errors.Wrap(err, "failed to delete managed instance")
 	}
-	err = gcp.waitForZonalComputeOperation(ctx, project, zone, r.Name)
+	err = gcp.waitForZonalComputeOperation(project, zone, r.Name)
 	if err != nil {
 		return errors.Wrap(err, "failed to wait for compute operation to complete successfully")
 	}
-	err = gcp.waitForManagedInstanceGroupStability(ctx, project, zone, managedInstanceGroupName)
+	err = gcp.waitForManagedInstanceGroupStability(project, zone, managedInstanceGroupName)
 	if err != nil {
 		return errors.Wrap(err, "failed to wait for managed instance group stability")
 	}

--- a/pkg/cloudprovider/gcp/cloud_provider_test.go
+++ b/pkg/cloudprovider/gcp/cloud_provider_test.go
@@ -106,8 +106,8 @@ func TestTimeSinceToBeDeletedTaintAdded(t *testing.T) {
 					},
 				},
 			},
-			now:                            time.Date(0, 0, 0, 0, 0, 60, 0, time.UTC),
-			timeSinceToBeDeletedTaintAdded: 60 * time.Second,
+			now:                            time.Date(0, 0, 0, 0, 1, 0, 0, time.UTC),
+			timeSinceToBeDeletedTaintAdded: time.Minute,
 		},
 		"futureTaint": {
 			node: &corev1.Node{
@@ -115,7 +115,7 @@ func TestTimeSinceToBeDeletedTaintAdded(t *testing.T) {
 					Taints: []corev1.Taint{
 						{
 							Key:    "ToBeDeletedByClusterAutoscaler",
-							Value:  fmt.Sprint(time.Date(0, 0, 0, 0, 0, 60, 0, time.UTC).Unix()),
+							Value:  fmt.Sprint(time.Date(0, 0, 0, 0, 1, 0, 0, time.UTC).Unix()),
 							Effect: corev1.TaintEffectNoSchedule,
 						},
 					},

--- a/pkg/cloudprovider/gcp/cloud_provider_test.go
+++ b/pkg/cloudprovider/gcp/cloud_provider_test.go
@@ -2,7 +2,9 @@ package gcp
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -77,6 +79,56 @@ func TestIsSpotInstance(t *testing.T) {
 			isSpotInstance, err := cloudProvider.IsSpotInstance(context.Background(), test.node)
 			require.Nil(t, err)
 			require.Equal(t, test.isSpotInstance, isSpotInstance)
+		})
+	}
+}
+
+func TestTimeSinceToBeDeletedTaintAdded(t *testing.T) {
+	tests := map[string]struct {
+		node                           *corev1.Node
+		now                            time.Time
+		timeSinceToBeDeletedTaintAdded time.Duration
+	}{
+		"missingTaint": {
+			node:                           &corev1.Node{},
+			now:                            time.Now(),
+			timeSinceToBeDeletedTaintAdded: 0,
+		},
+		"recentTaint": {
+			node: &corev1.Node{
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{
+							Key:    "ToBeDeletedByClusterAutoscaler",
+							Value:  fmt.Sprint(time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC).Unix()),
+							Effect: corev1.TaintEffectNoSchedule,
+						},
+					},
+				},
+			},
+			now:                            time.Date(0, 0, 0, 0, 0, 60, 0, time.UTC),
+			timeSinceToBeDeletedTaintAdded: 60 * time.Second,
+		},
+		"futureTaint": {
+			node: &corev1.Node{
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{
+							Key:    "ToBeDeletedByClusterAutoscaler",
+							Value:  fmt.Sprint(time.Date(0, 0, 0, 0, 0, 60, 0, time.UTC).Unix()),
+							Effect: corev1.TaintEffectNoSchedule,
+						},
+					},
+				},
+			},
+			now:                            time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC),
+			timeSinceToBeDeletedTaintAdded: 0,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			timeSinceToBeDeletedTaintAdded := timeSinceToBeDeletedTaintAdded(test.node, test.now)
+			require.Equal(t, test.timeSinceToBeDeletedTaintAdded, timeSinceToBeDeletedTaintAdded)
 		})
 	}
 }

--- a/pkg/cloudprovider/gcp/compute.go
+++ b/pkg/cloudprovider/gcp/compute.go
@@ -1,7 +1,6 @@
 package gcp
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -33,7 +32,7 @@ func getManagedInstanceGroupFromInstance(instance *compute.Instance) (string, er
 	return "", fmt.Errorf("failed to determine managed instance group for instance %s", instance.Name)
 }
 
-func (gcp *CloudProvider) waitForManagedInstanceGroupStability(ctx context.Context, project, zone, managedInstanceGroupName string) error {
+func (gcp *CloudProvider) waitForManagedInstanceGroupStability(project, zone, managedInstanceGroupName string) error {
 	for {
 		r, err := gcp.computeService.InstanceGroupManagers.Get(project, zone, managedInstanceGroupName).Do()
 		if err != nil {
@@ -46,13 +45,13 @@ func (gcp *CloudProvider) waitForManagedInstanceGroupStability(ctx context.Conte
 	}
 }
 
-func (gcp *CloudProvider) waitForZonalComputeOperation(ctx context.Context, project, zone, operationName string) error {
-	return waitForComputeOperation(ctx, project, func() (*compute.Operation, error) {
+func (gcp *CloudProvider) waitForZonalComputeOperation(project, zone, operationName string) error {
+	return waitForComputeOperation(func() (*compute.Operation, error) {
 		return gcp.computeService.ZoneOperations.Get(project, zone, operationName).Do()
 	})
 }
 
-func waitForComputeOperation(ctx context.Context, project string, getOperation func() (*compute.Operation, error)) error {
+func waitForComputeOperation(getOperation func() (*compute.Operation, error)) error {
 	for {
 		operation, err := getOperation()
 		if err != nil {

--- a/pkg/controller/spot_migrator.go
+++ b/pkg/controller/spot_migrator.go
@@ -153,7 +153,7 @@ func (sm *spotMigrator) run(ctx context.Context) error {
 		}
 
 		// Select one of the on-demand Nodes to delete
-		onDemandNode, err := selectNodeForDeletion(ctx, beforeDrainOnDemandNodes)
+		onDemandNode, err := selectNodeForDeletion(beforeDrainOnDemandNodes)
 		if err != nil {
 			return err
 		}
@@ -313,7 +313,7 @@ func (sm *spotMigrator) addToBeDeletedTaint(ctx context.Context, node *corev1.No
 // 3. Otherwise if there are any Nodes marked for deletion by the cluster-autoscaler then return the oldest
 // 4. Otherwise if there are any Nodes that are not running spot-migrator then return the oldest
 // 5. Otherwise return the oldest Node
-func selectNodeForDeletion(ctx context.Context, nodes []*corev1.Node) (*corev1.Node, error) {
+func selectNodeForDeletion(nodes []*corev1.Node) (*corev1.Node, error) {
 	// There should always be at least 1 Node to select from
 	if len(nodes) == 0 {
 		return nil, errors.New("failed to select Node from empty list")

--- a/pkg/controller/spot_migrator.go
+++ b/pkg/controller/spot_migrator.go
@@ -34,11 +34,6 @@ const (
 	// https://pkg.go.dev/github.com/robfig/cron#hdr-Predefined_schedules
 	defaultMigrationSchedule = "@hourly"
 
-	// https://github.com/kubernetes/autoscaler/blob/5bf33b23f2bcf5f9c8ccaf99d445e25366ee7f40/cluster-autoscaler/utils/taints/taints.go#L39-L40
-	toBeDeletedTaint = "ToBeDeletedByClusterAutoscaler"
-	// https://github.com/kubernetes/autoscaler/blob/5bf33b23f2bcf5f9c8ccaf99d445e25366ee7f40/cluster-autoscaler/utils/taints/taints.go#L41-L42
-	deletionCandidateTaint = "DeletionCandidateOfClusterAutoscaler"
-
 	// https://kubernetes.io/docs/reference/labels-annotations-taints/#node-role-kubernetes-io-control-plane
 	controlPlaneNodeRoleLabelKey = "node-role.kubernetes.io/control-plane"
 )
@@ -231,12 +226,12 @@ func (sm *spotMigrator) drainAndDeleteNode(ctx context.Context, node *corev1.Nod
 	}
 	logger.Info("Drained Node successfully")
 
-	logger.Info("Excluding Node from external load balancing")
-	err = sm.excludeNodeFromExternalLoadBalancing(ctx, node)
+	logger.Info("Adding taint ToBeDeletedByClusterAutoscaler")
+	err = sm.addToBeDeletedTaint(ctx, node)
 	if err != nil {
 		return err
 	}
-	logger.Info("Node excluded from external load balancing successfully")
+	logger.Info("Taint ToBeDeletedByClusterAutoscaler added successfully")
 
 	logger.Info("Deleting instance")
 	err = sm.CloudProvider.DeleteInstance(ctx, node)
@@ -278,14 +273,11 @@ func isSelectedForDeletion(node *corev1.Node) bool {
 	return ok && value == "true"
 }
 
-func (sm *spotMigrator) excludeNodeFromExternalLoadBalancing(ctx context.Context, node *corev1.Node) error {
-	// Adding the cluster autoscaler taint will tell the KCCM service controller to exclude the Node
-	// from load balancing. This may or may not trigger connection draining depending on provider:
-	// https://github.com/kubernetes/kubernetes/blob/b5ba7bc4f5f49760c821cae2f152a8000922e72e/staging/src/k8s.io/cloud-provider/controllers/service/controller.go#L1043-L1051
-	// Once KEP-3836 has been implemented the cluster autoscaler taint will start failing the
-	// kube-proxy health check to trigger proper connection draining:
-	// https://github.com/kubernetes/enhancements/tree/27ef0d9a740ae5058472aac4763483f0e7218c0e/keps/sig-network/3836-kube-proxy-improved-ingress-connectivity-reliability
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+// addToBeDeletedTaint adds the ToBeDeletedByClusterAutoscaler taint to the Node to tell kube-proxy
+// to start failing its healthz and subsequently load balancer health checks depending on provider:
+// https://github.com/kubernetes/enhancements/tree/27ef0d9a740ae5058472aac4763483f0e7218c0e/keps/sig-network/3836-kube-proxy-improved-ingress-connectivity-reliability
+func (sm *spotMigrator) addToBeDeletedTaint(ctx context.Context, node *corev1.Node) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		node, err := sm.Clientset.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -293,7 +285,7 @@ func (sm *spotMigrator) excludeNodeFromExternalLoadBalancing(ctx context.Context
 
 		hasToBeDeletedTaint := false
 		for _, taint := range node.Spec.Taints {
-			if taint.Key == toBeDeletedTaint {
+			if taint.Key == kubernetes.ToBeDeletedTaint {
 				hasToBeDeletedTaint = true
 				break
 			}
@@ -301,7 +293,7 @@ func (sm *spotMigrator) excludeNodeFromExternalLoadBalancing(ctx context.Context
 		if !hasToBeDeletedTaint {
 			// https://github.com/kubernetes/autoscaler/blob/5bf33b23f2bcf5f9c8ccaf99d445e25366ee7f40/cluster-autoscaler/utils/taints/taints.go#L166-L174
 			node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
-				Key:    toBeDeletedTaint,
+				Key:    kubernetes.ToBeDeletedTaint,
 				Value:  fmt.Sprint(time.Now().Unix()),
 				Effect: corev1.TaintEffectNoSchedule,
 			})
@@ -313,23 +305,6 @@ func (sm *spotMigrator) excludeNodeFromExternalLoadBalancing(ctx context.Context
 
 		return nil
 	})
-	if err != nil {
-		return err
-	}
-
-	// We also add the node.kubernetes.io/exclude-from-external-load-balancers label since this
-	// triggers instant KCCM service controller reconciliation instead of having to wait for the
-	// Node sync period:
-	// https://kubernetes.io/docs/reference/labels-annotations-taints/#node-kubernetes-io-exclude-from-external-load-balancers
-	// https://github.com/kubernetes/kubernetes/blob/b5ba7bc4f5f49760c821cae2f152a8000922e72e/staging/src/k8s.io/cloud-provider/controllers/service/controller.go#L699-L712
-	// https://github.com/kubernetes/kubernetes/blob/b5ba7bc4f5f49760c821cae2f152a8000922e72e/staging/src/k8s.io/cloud-provider/controllers/service/controller.go#L54-L55
-	patch := []byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"true"}}}`, corev1.LabelNodeExcludeBalancers))
-	_, err = sm.Clientset.CoreV1().Nodes().Patch(ctx, node.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
-	if err != nil {
-		return errors.Wrapf(err, "failed to label Node %s", node.Name)
-	}
-
-	return nil
 }
 
 // selectNodeForDeletion attempts the find the best Node to delete using the following algorithm:
@@ -372,7 +347,7 @@ func selectNodeForDeletion(ctx context.Context, nodes []*corev1.Node) (*corev1.N
 	for _, node := range nodes {
 		for _, taint := range node.Spec.Taints {
 			// https://github.com/kubernetes/autoscaler/blob/299c9637229fb2bf849c1d86243fe2948d14101e/cluster-autoscaler/utils/taints/taints.go#L119
-			if taint.Key == toBeDeletedTaint && taint.Effect == corev1.TaintEffectNoSchedule {
+			if taint.Key == kubernetes.ToBeDeletedTaint && taint.Effect == corev1.TaintEffectNoSchedule {
 				return node, nil
 			}
 		}
@@ -383,7 +358,7 @@ func selectNodeForDeletion(ctx context.Context, nodes []*corev1.Node) (*corev1.N
 	for _, node := range nodes {
 		for _, taint := range node.Spec.Taints {
 			// https://github.com/kubernetes/autoscaler/blob/299c9637229fb2bf849c1d86243fe2948d14101e/cluster-autoscaler/utils/taints/taints.go#L124
-			if taint.Key == deletionCandidateTaint && taint.Effect == corev1.TaintEffectPreferNoSchedule {
+			if taint.Key == kubernetes.DeletionCandidateTaint && taint.Effect == corev1.TaintEffectPreferNoSchedule {
 				return node, nil
 			}
 		}

--- a/pkg/controller/spot_migrator_test.go
+++ b/pkg/controller/spot_migrator_test.go
@@ -459,20 +459,19 @@ func TestIsSelectedForDeletion(t *testing.T) {
 	}
 }
 
-func TestExcludeNodeFromExternalLoadBalancing(t *testing.T) {
+func TestAddToBeDeletedTaint(t *testing.T) {
 	ctx := context.Background()
 	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
 	sm := &spotMigrator{
 		Clientset: fake.NewSimpleClientset(node),
 	}
 
-	err := sm.excludeNodeFromExternalLoadBalancing(ctx, node)
+	err := sm.addToBeDeletedTaint(ctx, node)
 	require.Nil(t, err)
 
 	node, err = sm.Clientset.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
 	require.Nil(t, err)
 
-	// Verify that the cluster autoscaler taint was added
 	hasToBeDeletedTaint := false
 	for _, taint := range node.Spec.Taints {
 		if taint.Key == "ToBeDeletedByClusterAutoscaler" && taint.Effect == "NoSchedule" {
@@ -481,10 +480,6 @@ func TestExcludeNodeFromExternalLoadBalancing(t *testing.T) {
 		}
 	}
 	require.True(t, hasToBeDeletedTaint)
-
-	// Verify that the exclusion label was added
-	_, ok := node.Labels["node.kubernetes.io/exclude-from-external-load-balancers"]
-	require.True(t, ok)
 }
 
 func TestListOnDemandNodes(t *testing.T) {

--- a/pkg/controller/spot_migrator_test.go
+++ b/pkg/controller/spot_migrator_test.go
@@ -75,7 +75,7 @@ func TestSpotMigratorNodeCreatedTrueOnNodeCreate(t *testing.T) {
 
 func TestSpotMigratorSelectNodeForDeletionErrorOnEmptyList(t *testing.T) {
 	nodes := []*corev1.Node{}
-	_, err := selectNodeForDeletion(context.Background(), nodes)
+	_, err := selectNodeForDeletion(nodes)
 	require.NotNil(t, err)
 }
 
@@ -115,7 +115,7 @@ func TestSpotMigratorSelectNodeForDeletionPreferOldest(t *testing.T) {
 			},
 		},
 	}
-	node, err := selectNodeForDeletion(context.Background(), nodes)
+	node, err := selectNodeForDeletion(nodes)
 	require.Nil(t, err)
 	require.Equal(t, "oldest", node.Name)
 }
@@ -158,7 +158,7 @@ func TestSpotMigratorSelectNodeForDeletionDoNotPreferLocalNode(t *testing.T) {
 			},
 		},
 	}
-	node, err := selectNodeForDeletion(context.Background(), nodes)
+	node, err := selectNodeForDeletion(nodes)
 	require.Nil(t, err)
 	require.Equal(t, "secondoldest", node.Name)
 }
@@ -205,7 +205,7 @@ func TestSpotMigratorSelectNodeForDeletionPreferNodesMarkedPreferNoScheduleByClu
 			},
 		},
 	}
-	node, err := selectNodeForDeletion(context.Background(), nodes)
+	node, err := selectNodeForDeletion(nodes)
 	require.Nil(t, err)
 	require.Equal(t, "secondoldest", node.Name)
 }
@@ -258,7 +258,7 @@ func TestSpotMigratorSelectNodeForDeletionPreferNodesMarkedNoScheduleByClusterAu
 			},
 		},
 	}
-	node, err := selectNodeForDeletion(context.Background(), nodes)
+	node, err := selectNodeForDeletion(nodes)
 	require.Nil(t, err)
 	require.Equal(t, "thirdoldest", node.Name)
 }
@@ -297,7 +297,7 @@ func TestSpotMigratorSelectNodeForDeletionPreferUnschedulable(t *testing.T) {
 			},
 		},
 	}
-	node, err := selectNodeForDeletion(context.Background(), nodes)
+	node, err := selectNodeForDeletion(nodes)
 	require.Nil(t, err)
 	require.True(t, node.Spec.Unschedulable)
 }
@@ -339,7 +339,7 @@ func TestSpotMigratorSelectNodeForDeletionPreferSelectedForDeletion(t *testing.T
 			},
 		},
 	}
-	node, err := selectNodeForDeletion(context.Background(), nodes)
+	node, err := selectNodeForDeletion(nodes)
 	require.Nil(t, err)
 	require.True(t, isSelectedForDeletion(node))
 }

--- a/pkg/kubernetes/drain.go
+++ b/pkg/kubernetes/drain.go
@@ -21,7 +21,7 @@ const (
 	nodeDrainTimeout = time.Hour
 )
 
-// We use the default drain implementation:
+// DrainNode uses the default drain implementation to drain the Node:
 // https://github.com/kubernetes/kubectl/blob/3ec401449e5821ad954942c7ecec9d2c90ecaaa1/pkg/drain/default.go
 func DrainNode(ctx context.Context, clientset kubernetes.Interface, node *corev1.Node) error {
 	// https://github.com/kubernetes/kubectl/blob/3ec401449e5821ad954942c7ecec9d2c90ecaaa1/pkg/cmd/drain/drain.go#L147-L160

--- a/pkg/kubernetes/node.go
+++ b/pkg/kubernetes/node.go
@@ -1,8 +1,7 @@
 package kubernetes
 
 const (
-	// https://github.com/kubernetes/autoscaler/blob/5bf33b23f2bcf5f9c8ccaf99d445e25366ee7f40/cluster-autoscaler/utils/taints/taints.go#L39-L40
-	ToBeDeletedTaint = "ToBeDeletedByClusterAutoscaler"
-	// https://github.com/kubernetes/autoscaler/blob/5bf33b23f2bcf5f9c8ccaf99d445e25366ee7f40/cluster-autoscaler/utils/taints/taints.go#L41-L42
+	// https://github.com/kubernetes/autoscaler/blob/5bf33b23f2bcf5f9c8ccaf99d445e25366ee7f40/cluster-autoscaler/utils/taints/taints.go#L39-L42
+	ToBeDeletedTaint       = "ToBeDeletedByClusterAutoscaler"
 	DeletionCandidateTaint = "DeletionCandidateOfClusterAutoscaler"
 )

--- a/pkg/kubernetes/node.go
+++ b/pkg/kubernetes/node.go
@@ -1,0 +1,8 @@
+package kubernetes
+
+const (
+	// https://github.com/kubernetes/autoscaler/blob/5bf33b23f2bcf5f9c8ccaf99d445e25366ee7f40/cluster-autoscaler/utils/taints/taints.go#L39-L40
+	ToBeDeletedTaint = "ToBeDeletedByClusterAutoscaler"
+	// https://github.com/kubernetes/autoscaler/blob/5bf33b23f2bcf5f9c8ccaf99d445e25366ee7f40/cluster-autoscaler/utils/taints/taints.go#L41-L42
+	DeletionCandidateTaint = "DeletionCandidateOfClusterAutoscaler"
+)

--- a/pkg/kubernetes/port_forward.go
+++ b/pkg/kubernetes/port_forward.go
@@ -19,7 +19,7 @@ import (
 // port which is returned as well as a function to stop the port forward when finished
 func PortForward(ctx context.Context, restConfig *rest.Config, podNamespace, podName string, port int) (uint16, func() error, error) {
 	stopChan, readyChan, errChan := make(chan struct{}, 1), make(chan struct{}, 1), make(chan error, 1)
-	forwarder, err := createForwarder(ctx, restConfig, stopChan, readyChan, podNamespace, podName, port)
+	forwarder, err := createForwarder(restConfig, stopChan, readyChan, podNamespace, podName, port)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -53,7 +53,7 @@ func PortForward(ctx context.Context, restConfig *rest.Config, podNamespace, pod
 	return forwardedPorts[0].Local, stop, nil
 }
 
-func createForwarder(ctx context.Context, restConfig *rest.Config, stopChan, readyChan chan struct{}, podNamespace, podName string, port int) (*portforward.PortForwarder, error) {
+func createForwarder(restConfig *rest.Config, stopChan, readyChan chan struct{}, podNamespace, podName string, port int) (*portforward.PortForwarder, error) {
 	// Discard output to avoid race conditions
 	out, errOut := io.Discard, io.Discard
 

--- a/pkg/kubernetes/watch_test.go
+++ b/pkg/kubernetes/watch_test.go
@@ -7,11 +7,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
-	apiwatch "k8s.io/apimachinery/pkg/watch"
 )
 
 func TestParseWatchEventPodObject(t *testing.T) {
-	event := apiwatch.Event{
+	event := watch.Event{
 		Object: &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
@@ -26,7 +25,7 @@ func TestParseWatchEventPodObject(t *testing.T) {
 }
 
 func TestParseWatchEventErrorObject(t *testing.T) {
-	event := apiwatch.Event{
+	event := watch.Event{
 		Type: watch.Error,
 		Object: &metav1.Status{
 			Message: "message",


### PR DESCRIPTION
This PR uses the taint ToBeDeletedByClusterAutoscaler described in [KEP-3836](https://github.com/kubernetes/enhancements/tree/27ef0d9a740ae5058472aac4763483f0e7218c0e/keps/sig-network/3836-kube-proxy-improved-ingress-connectivity-reliability) to implement connection draining on GCP